### PR TITLE
Add OpenApi JSON view for RestApi model

### DIFF
--- a/src/Modeler.CLI/Program.cs
+++ b/src/Modeler.CLI/Program.cs
@@ -56,6 +56,9 @@ using Modeler.RestApiModel.Sample.Models;
 using Modeler.RestApiModel.Sample.Views.AsciiDoc;
 using Modeler.RestApiModel.Sample.Views.AsciiDoc.Outputs;
 using Modeler.RestApiModel.Views.AsciiDoc;
+using Modeler.RestApiModel.Sample.Views.OpenApi;
+using Modeler.RestApiModel.Sample.Views.OpenApi.Outputs;
+using Modeler.RestApiModel.Views.OpenApi;
 using MermaidClassDiagramViewGenerator = Modeler.ConceptualModel.Views.Mermaid.MermaidClassDiagramViewGenerator;
 
 if (args.Length != 1)
@@ -85,6 +88,7 @@ GenerateMermaidEventsFlowViews(documentationPath);
 GenerateMarkdownEventsFlowViews(documentationPath);
 GenerateAsciiDocEventsFlowViews(documentationPath);
 GenerateAsciiDocRestApiViews(documentationPath);
+GenerateOpenApiRestApiViews(documentationPath);
 
 Console.WriteLine("Documentation generated.");
 
@@ -349,4 +353,18 @@ void GenerateAsciiDocRestApiViews(string path)
 
     var modelsOutput = new FileSystemAsciiDocRestApiViewOutput<AsciiDocApiModelsView>(viewsPath);
     new AsciiDocApiModelsViewGenerator(modelsOutput).Generate(apiModelViews);
+}
+
+void GenerateOpenApiRestApiViews(string path)
+{
+    var model = HRRestApiModel.GetInstance();
+
+    var views = new OpenApiViewsFactory(
+        model,
+        Assembly.GetAssembly(typeof(OpenApiJsonViewDefinition))!).Views;
+
+    var viewsPath = Path.Combine(path, "Models/RestApi");
+
+    var output = new FileSystemOpenApiRestApiViewOutput<OpenApiView>(viewsPath);
+    new OpenApiViewGenerator(output).Generate(views);
 }

--- a/src/Modeler.sln
+++ b/src/Modeler.sln
@@ -138,6 +138,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Views", "Views", "{B2460519
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Modeler.RestApiModel.Views.AsciiDoc", "Models\RestApiModel\Modeler.RestApiModel.Views.AsciiDoc\Modeler.RestApiModel.Views.AsciiDoc.csproj", "{F5419797-ADA1-4B56-A154-CA5BF4522BD6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Modeler.RestApiModel.Views.OpenApi", "Models\RestApiModel\Modeler.RestApiModel.Views.OpenApi\Modeler.RestApiModel.Views.OpenApi.csproj", "{AFDF9627-4278-4055-9DED-D55D50EA2D13}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Modeler.RestApiModel.Sample", "Samples\RestApi\Modeler.RestApiModel.Sample\Modeler.RestApiModel.Sample.csproj", "{674DC40E-43CE-4FE4-B7B0-AFE65D9E8A28}"
 EndProject
 Global
@@ -310,6 +312,10 @@ Global
                 {F5419797-ADA1-4B56-A154-CA5BF4522BD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {F5419797-ADA1-4B56-A154-CA5BF4522BD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {F5419797-ADA1-4B56-A154-CA5BF4522BD6}.Release|Any CPU.Build.0 = Release|Any CPU
+                {AFDF9627-4278-4055-9DED-D55D50EA2D13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {AFDF9627-4278-4055-9DED-D55D50EA2D13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {AFDF9627-4278-4055-9DED-D55D50EA2D13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {AFDF9627-4278-4055-9DED-D55D50EA2D13}.Release|Any CPU.Build.0 = Release|Any CPU
                 {674DC40E-43CE-4FE4-B7B0-AFE65D9E8A28}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
                 {674DC40E-43CE-4FE4-B7B0-AFE65D9E8A28}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {674DC40E-43CE-4FE4-B7B0-AFE65D9E8A28}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -381,6 +387,7 @@ Global
                 {B2460519-3AD1-4640-B1CA-88A5952E008D} = {D5673E66-436E-4C9D-9D32-4274FA2953A6}
                 {50F0E065-24A2-4AE7-B172-6856414FD528} = {D5673E66-436E-4C9D-9D32-4274FA2953A6}
                 {F5419797-ADA1-4B56-A154-CA5BF4522BD6} = {B2460519-3AD1-4640-B1CA-88A5952E008D}
+                {AFDF9627-4278-4055-9DED-D55D50EA2D13} = {B2460519-3AD1-4640-B1CA-88A5952E008D}
                 {E0DC08CC-58BE-4770-A07C-08424DD22CFC} = {F41E42BA-7F4F-47D5-91D1-B4E53215C268}
                 {674DC40E-43CE-4FE4-B7B0-AFE65D9E8A28} = {E0DC08CC-58BE-4770-A07C-08424DD22CFC}
         EndGlobalSection

--- a/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/IOpenApiRestApiViewsOutput.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/IOpenApiRestApiViewsOutput.cs
@@ -1,0 +1,8 @@
+namespace Modeler.RestApiModel.Views.OpenApi;
+
+public interface IOpenApiRestApiViewsOutput<T>
+{
+    void Execute(List<OpenApiRestApiViewsOutputItem<T>> views);
+}
+
+public record OpenApiRestApiViewsOutputItem<T>(string Id, T View, string Content);

--- a/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/Modeler.RestApiModel.Views.OpenApi.csproj
+++ b/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/Modeler.RestApiModel.Views.OpenApi.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Modeler.RestApiModel\Modeler.RestApiModel.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/OpenApiView.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/OpenApiView.cs
@@ -1,0 +1,18 @@
+namespace Modeler.RestApiModel.Views.OpenApi;
+
+public class OpenApiView
+{
+    public OpenApiView(string id, Model model)
+    {
+        Id = id;
+        Model = model;
+    }
+
+    public string Id { get; }
+
+    public Model Model { get; }
+}
+
+public abstract class OpenApiViewDefinition
+{
+}

--- a/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/OpenApiViewGenerator.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/OpenApiViewGenerator.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+
+namespace Modeler.RestApiModel.Views.OpenApi;
+
+public class OpenApiViewGenerator
+{
+    private readonly IOpenApiRestApiViewsOutput<OpenApiView> _viewsOutput;
+
+    public OpenApiViewGenerator(IOpenApiRestApiViewsOutput<OpenApiView> viewsOutput)
+    {
+        _viewsOutput = viewsOutput;
+    }
+
+    public void Generate(List<OpenApiView> views)
+    {
+        var outputItems = new List<OpenApiRestApiViewsOutputItem<OpenApiView>>();
+        foreach (var view in views)
+        {
+            var spec = GenerateSpecification(view.Model);
+            var json = JsonSerializer.Serialize(spec, new JsonSerializerOptions { WriteIndented = true });
+            outputItems.Add(new OpenApiRestApiViewsOutputItem<OpenApiView>(view.Id, view, json));
+        }
+        _viewsOutput.Execute(outputItems);
+    }
+
+    private static object GenerateSpecification(Model model)
+    {
+        var paths = new Dictionary<string, Dictionary<string, object>>();
+        foreach (var ep in model.GetEndpoints())
+        {
+            if (!paths.ContainsKey(ep.Path))
+            {
+                paths[ep.Path] = new Dictionary<string, object>();
+            }
+
+            var methodObj = new Dictionary<string, object>
+            {
+                ["summary"] = ep.Name
+            };
+
+            if (ep.RequestModel != null)
+            {
+                methodObj["requestBody"] = new Dictionary<string, object>
+                {
+                    ["required"] = true,
+                    ["content"] = new Dictionary<string, object>
+                    {
+                        ["application/json"] = new Dictionary<string, object>
+                        {
+                            ["schema"] = new Dictionary<string, object>
+                            {
+                                ["$ref"] = $"#/components/schemas/{ep.RequestModel.Name}"
+                            }
+                        }
+                    }
+                };
+            }
+
+            if (ep.ResponseModel != null)
+            {
+                methodObj["responses"] = new Dictionary<string, object>
+                {
+                    ["200"] = new Dictionary<string, object>
+                    {
+                        ["description"] = "Success",
+                        ["content"] = new Dictionary<string, object>
+                        {
+                            ["application/json"] = new Dictionary<string, object>
+                            {
+                                ["schema"] = new Dictionary<string, object>
+                                {
+                                    ["$ref"] = $"#/components/schemas/{ep.ResponseModel.Name}"
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+
+            paths[ep.Path][ep.Method.ToLower()] = methodObj;
+        }
+
+        var schemas = new Dictionary<string, object>();
+        foreach (var apiModel in model.GetApiModels())
+        {
+            var properties = new Dictionary<string, object>();
+            var required = new List<string>();
+            foreach (var attr in apiModel.Attributes)
+            {
+                properties[attr.Name] = new Dictionary<string, object>
+                {
+                    ["type"] = attr.Type
+                };
+                if (attr.Required)
+                {
+                    required.Add(attr.Name);
+                }
+            }
+            var schema = new Dictionary<string, object>
+            {
+                ["type"] = "object",
+                ["properties"] = properties
+            };
+            if (required.Count > 0)
+            {
+                schema["required"] = required;
+            }
+            schemas[apiModel.Name] = schema;
+        }
+
+        return new Dictionary<string, object>
+        {
+            ["openapi"] = "3.0.0",
+            ["info"] = new Dictionary<string, object>
+            {
+                ["title"] = "Generated API",
+                ["version"] = "1.0.0"
+            },
+            ["paths"] = paths,
+            ["components"] = new Dictionary<string, object>
+            {
+                ["schemas"] = schemas
+            }
+        };
+    }
+}

--- a/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/OpenApiViewsFactory.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/OpenApiViewsFactory.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+
+namespace Modeler.RestApiModel.Views.OpenApi;
+
+public class OpenApiViewsFactory
+{
+    private readonly List<OpenApiView> _views;
+    private readonly Model _model;
+
+    public OpenApiViewsFactory(Model model, Assembly viewsAssembly)
+    {
+        _model = model;
+        _views = new List<OpenApiView>();
+        InitializeViews(viewsAssembly);
+    }
+
+    public List<OpenApiView> Views => _views.ToList();
+
+    private void InitializeViews(Assembly viewsAssembly)
+    {
+        var types = viewsAssembly
+            .GetTypes()
+            .Where(t => typeof(OpenApiViewDefinition).IsAssignableFrom(t));
+        foreach (var type in types)
+        {
+            var method = type.GetMethod("Create", BindingFlags.Static | BindingFlags.Public);
+            if (method != null)
+            {
+                var view = method.Invoke(null, new object?[] { _model });
+                _views.Add((OpenApiView)view!);
+            }
+        }
+    }
+}

--- a/src/Samples/RestApi/Modeler.RestApiModel.Sample/Modeler.RestApiModel.Sample.csproj
+++ b/src/Samples/RestApi/Modeler.RestApiModel.Sample/Modeler.RestApiModel.Sample.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Models\RestApiModel\Modeler.RestApiModel.Views.AsciiDoc\Modeler.RestApiModel.Views.AsciiDoc.csproj" />
+    <ProjectReference Include="..\..\..\Models\RestApiModel\Modeler.RestApiModel.Views.OpenApi\Modeler.RestApiModel.Views.OpenApi.csproj" />
     <ProjectReference Include="..\..\..\Models\RestApiModel\Modeler.RestApiModel\Modeler.RestApiModel.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Samples/RestApi/Modeler.RestApiModel.Sample/Views/OpenApi/OpenApiJsonViewDefinition.cs
+++ b/src/Samples/RestApi/Modeler.RestApiModel.Sample/Views/OpenApi/OpenApiJsonViewDefinition.cs
@@ -1,0 +1,14 @@
+using Modeler.RestApiModel.Sample.Models;
+using Modeler.RestApiModel.Views.OpenApi;
+
+namespace Modeler.RestApiModel.Sample.Views.OpenApi;
+
+public class OpenApiJsonViewDefinition : OpenApiViewDefinition
+{
+    public const string Id = "RestApiOpenApi";
+
+    public static OpenApiView Create(HRRestApiModel model)
+    {
+        return new OpenApiView(Id, model);
+    }
+}

--- a/src/Samples/RestApi/Modeler.RestApiModel.Sample/Views/OpenApi/Outputs/FileSystemOpenApiRestApiViewOutput.cs
+++ b/src/Samples/RestApi/Modeler.RestApiModel.Sample/Views/OpenApi/Outputs/FileSystemOpenApiRestApiViewOutput.cs
@@ -1,0 +1,31 @@
+using Modeler.RestApiModel.Views.OpenApi;
+
+namespace Modeler.RestApiModel.Sample.Views.OpenApi.Outputs;
+
+public class FileSystemOpenApiRestApiViewOutput<T> : IOpenApiRestApiViewsOutput<T>
+{
+    private readonly string _absoluteDirectoryPath;
+    private readonly IDictionary<string, string> _relativePaths;
+
+    public FileSystemOpenApiRestApiViewOutput(string absoluteDirectoryPath)
+    {
+        _absoluteDirectoryPath = absoluteDirectoryPath;
+        _relativePaths = new Dictionary<string, string>();
+        _relativePaths.Add(OpenApiJsonViewDefinition.Id, "OpenApi.json");
+    }
+
+    public void Execute(List<OpenApiRestApiViewsOutputItem<T>> views)
+    {
+        if (!Directory.Exists(_absoluteDirectoryPath))
+        {
+            Directory.CreateDirectory(_absoluteDirectoryPath);
+        }
+
+        foreach (var outputItem in views)
+        {
+            var relativePath = _relativePaths[outputItem.Id];
+            var path = Path.Combine(_absoluteDirectoryPath, relativePath);
+            File.WriteAllText(path, outputItem.Content);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an OpenApi view and generator for RestApi model
- expose a file system output and view definition for the sample
- call new generator from CLI

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445092a2348322b1633ad8e6a08c40