### PR TITLE
Add OpenAPI YAML view generator

### DIFF
--- a/src/Modeler.CLI/Program.cs
+++ b/src/Modeler.CLI/Program.cs
@@ -366,5 +366,10 @@ void GenerateOpenApiRestApiViews(string path)
     var viewsPath = Path.Combine(path, "Models/RestApi");
 
     var output = new FileSystemOpenApiRestApiViewOutput<OpenApiView>(viewsPath);
-    new OpenApiViewGenerator(output).Generate(views);
+
+    var jsonViews = views.Where(v => v.Id == OpenApiJsonViewDefinition.Id).ToList();
+    var yamlViews = views.Where(v => v.Id == OpenApiYamlViewDefinition.Id).ToList();
+
+    new OpenApiViewGenerator(output).Generate(jsonViews);
+    new OpenApiYamlViewGenerator(output).Generate(yamlViews);
 }

--- a/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/OpenApiYamlViewGenerator.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/OpenApiYamlViewGenerator.cs
@@ -1,0 +1,195 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Modeler.RestApiModel.Views.OpenApi;
+
+public class OpenApiYamlViewGenerator
+{
+    private readonly IOpenApiRestApiViewsOutput<OpenApiView> _viewsOutput;
+
+    public OpenApiYamlViewGenerator(IOpenApiRestApiViewsOutput<OpenApiView> viewsOutput)
+    {
+        _viewsOutput = viewsOutput;
+    }
+
+    public void Generate(List<OpenApiView> views)
+    {
+        var outputItems = new List<OpenApiRestApiViewsOutputItem<OpenApiView>>();
+        foreach (var view in views)
+        {
+            var spec = GenerateSpecification(view.Model);
+            var yaml = ConvertToYaml(spec);
+            outputItems.Add(new OpenApiRestApiViewsOutputItem<OpenApiView>(view.Id, view, yaml));
+        }
+        _viewsOutput.Execute(outputItems);
+    }
+
+    private static string ConvertToYaml(object obj)
+    {
+        var element = JsonSerializer.SerializeToElement(obj);
+        var sb = new StringBuilder();
+        WriteYaml(element, sb, 0);
+        return sb.ToString();
+    }
+
+    private static void WriteYaml(JsonElement element, StringBuilder sb, int indent)
+    {
+        var indentStr = new string(' ', indent);
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var prop in element.EnumerateObject())
+                {
+                    sb.Append(indentStr);
+                    sb.Append(prop.Name);
+                    sb.Append(':');
+                    if (prop.Value.ValueKind == JsonValueKind.Object || prop.Value.ValueKind == JsonValueKind.Array)
+                    {
+                        sb.AppendLine();
+                        WriteYaml(prop.Value, sb, indent + 2);
+                    }
+                    else
+                    {
+                        sb.Append(' ');
+                        sb.Append(ConvertScalar(prop.Value));
+                        sb.AppendLine();
+                    }
+                }
+                break;
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                {
+                    sb.Append(indentStr);
+                    sb.Append("- ");
+                    if (item.ValueKind == JsonValueKind.Object || item.ValueKind == JsonValueKind.Array)
+                    {
+                        sb.AppendLine();
+                        WriteYaml(item, sb, indent + 2);
+                    }
+                    else
+                    {
+                        sb.Append(ConvertScalar(item));
+                        sb.AppendLine();
+                    }
+                }
+                break;
+            default:
+                sb.Append(indentStr);
+                sb.Append(ConvertScalar(element));
+                sb.AppendLine();
+                break;
+        }
+    }
+
+    private static string ConvertScalar(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => "\"" + element.GetString()!.Replace("\"", "\\\"") + "\"",
+            JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False => element.GetRawText(),
+            JsonValueKind.Null => "null",
+            _ => element.GetRawText()
+        };
+    }
+
+    private static object GenerateSpecification(Model model)
+    {
+        var paths = new Dictionary<string, Dictionary<string, object>>();
+        foreach (var ep in model.GetEndpoints())
+        {
+            if (!paths.ContainsKey(ep.Path))
+            {
+                paths[ep.Path] = new Dictionary<string, object>();
+            }
+
+            var methodObj = new Dictionary<string, object>
+            {
+                ["summary"] = ep.Name
+            };
+
+            if (ep.RequestModel != null)
+            {
+                methodObj["requestBody"] = new Dictionary<string, object>
+                {
+                    ["required"] = true,
+                    ["content"] = new Dictionary<string, object>
+                    {
+                        ["application/json"] = new Dictionary<string, object>
+                        {
+                            ["schema"] = new Dictionary<string, object>
+                            {
+                                ["$ref"] = $"#/components/schemas/{ep.RequestModel.Name}"
+                            }
+                        }
+                    }
+                };
+            }
+
+            if (ep.ResponseModel != null)
+            {
+                methodObj["responses"] = new Dictionary<string, object>
+                {
+                    ["200"] = new Dictionary<string, object>
+                    {
+                        ["description"] = "Success",
+                        ["content"] = new Dictionary<string, object>
+                        {
+                            ["application/json"] = new Dictionary<string, object>
+                            {
+                                ["schema"] = new Dictionary<string, object>
+                                {
+                                    ["$ref"] = $"#/components/schemas/{ep.ResponseModel.Name}"
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+
+            paths[ep.Path][ep.Method.ToLower()] = methodObj;
+        }
+
+        var schemas = new Dictionary<string, object>();
+        foreach (var apiModel in model.GetApiModels())
+        {
+            var properties = new Dictionary<string, object>();
+            var required = new List<string>();
+            foreach (var attr in apiModel.Attributes)
+            {
+                properties[attr.Name] = new Dictionary<string, object>
+                {
+                    ["type"] = attr.Type
+                };
+                if (attr.Required)
+                {
+                    required.Add(attr.Name);
+                }
+            }
+            var schema = new Dictionary<string, object>
+            {
+                ["type"] = "object",
+                ["properties"] = properties
+            };
+            if (required.Count > 0)
+            {
+                schema["required"] = required;
+            }
+            schemas[apiModel.Name] = schema;
+        }
+
+        return new Dictionary<string, object>
+        {
+            ["openapi"] = "3.0.0",
+            ["info"] = new Dictionary<string, object>
+            {
+                ["title"] = "Generated API",
+                ["version"] = "1.0.0"
+            },
+            ["paths"] = paths,
+            ["components"] = new Dictionary<string, object>
+            {
+                ["schemas"] = schemas
+            }
+        };
+    }
+}

--- a/src/Samples/RestApi/Modeler.RestApiModel.Sample/Views/OpenApi/OpenApiYamlViewDefinition.cs
+++ b/src/Samples/RestApi/Modeler.RestApiModel.Sample/Views/OpenApi/OpenApiYamlViewDefinition.cs
@@ -1,0 +1,14 @@
+using Modeler.RestApiModel.Sample.Models;
+using Modeler.RestApiModel.Views.OpenApi;
+
+namespace Modeler.RestApiModel.Sample.Views.OpenApi;
+
+public class OpenApiYamlViewDefinition : OpenApiViewDefinition
+{
+    public const string Id = "RestApiOpenApiYaml";
+
+    public static OpenApiView Create(HRRestApiModel model)
+    {
+        return new OpenApiView(Id, model);
+    }
+}

--- a/src/Samples/RestApi/Modeler.RestApiModel.Sample/Views/OpenApi/Outputs/FileSystemOpenApiRestApiViewOutput.cs
+++ b/src/Samples/RestApi/Modeler.RestApiModel.Sample/Views/OpenApi/Outputs/FileSystemOpenApiRestApiViewOutput.cs
@@ -12,6 +12,7 @@ public class FileSystemOpenApiRestApiViewOutput<T> : IOpenApiRestApiViewsOutput<
         _absoluteDirectoryPath = absoluteDirectoryPath;
         _relativePaths = new Dictionary<string, string>();
         _relativePaths.Add(OpenApiJsonViewDefinition.Id, "OpenApi.json");
+        _relativePaths.Add(OpenApiYamlViewDefinition.Id, "OpenApi.yaml");
     }
 
     public void Execute(List<OpenApiRestApiViewsOutputItem<T>> views)


### PR DESCRIPTION
## Summary
- create `OpenApiYamlViewGenerator` for YAML specification
- support YAML view definition and output path
- generate JSON and YAML OpenAPI specs in CLI

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845195811548322ac023ecb220a15a7