### PR TITLE
Add State model docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,7 @@ Models the states of an object and the transitions between them based on events.
 1. AsciiDoc Table
 2. PlantUML State Diagram
 3. Markdown Table
+
+#### Documentation
+
+See [State Model Documentation](docs/Models/State).

--- a/docs/Models/State/AbsenceStateMachine.puml
+++ b/docs/Models/State/AbsenceStateMachine.puml
@@ -1,0 +1,16 @@
+@startuml
+state Registered
+state "To Decide" as ToDecide
+state "Needs Clarification" as NeedsClarification
+state Accepted
+state Rejected
+
+[*] --> Registered
+Registered --> ToDecide : Sent To Decision
+ToDecide --> NeedsClarification : Clarification Requested
+NeedsClarification --> ToDecide : Sent To Decision
+ToDecide --> Accepted : Accepted
+ToDecide --> Rejected : Rejected
+Accepted --> [*]
+Rejected --> [*]
+@enduml

--- a/docs/Models/State/README.md
+++ b/docs/Models/State/README.md
@@ -1,0 +1,104 @@
+# State Machine
+
+## Example
+
+See full example [here](../../../src/Samples/State/Modeler.StateModel.Sample).
+
+## Design
+
+### Events
+
+Events are defined by inheriting from `TransitionEvent`:
+
+```csharp
+public class SentToDecisionEvent : TransitionEvent
+{
+    public static SentToDecisionEvent Create() => new SentToDecisionEvent();
+
+    private SentToDecisionEvent() : base("Sent To Decision")
+    {
+    }
+}
+```
+
+### States
+
+States are defined by inheriting from `State`:
+
+```csharp
+public class RegisteredState : State
+{
+    public RegisteredState() : base("Registered")
+    {
+    }
+}
+```
+
+### State machine
+
+A state machine organizes states and transitions:
+
+```csharp
+public class AbsenceStateMachine : StateMachine
+{
+    public static StateMachine Create(HRStateModel model)
+    {
+        var stateMachine = new AbsenceStateMachine();
+        var registeredState = new RegisteredState();
+        var toDecideState = new ToDecideState();
+        var needsClarificationState = new NeedsClarificationState();
+        var acceptedState = new AcceptedState();
+        var rejectedState = new RejectedState();
+
+        var sentToDecisionEvent = model.GetEvent<SentToDecisionEvent>();
+        var acceptedEvent = model.GetEvent<AcceptedEvent>();
+        var rejectedEvent = model.GetEvent<RejectedEvent>();
+        var answeredEvent = model.GetEvent<ClarificationRequestedEvent>();
+
+        stateMachine.StartFrom(registeredState);
+        stateMachine.AddTransition(registeredState, sentToDecisionEvent, toDecideState);
+        stateMachine.AddTransition(toDecideState, answeredEvent, needsClarificationState);
+        stateMachine.AddTransition(needsClarificationState, sentToDecisionEvent, toDecideState);
+        stateMachine.AddTransition(toDecideState, acceptedEvent, acceptedState);
+        stateMachine.AddTransition(toDecideState, rejectedEvent, rejectedState);
+        stateMachine.SetAsEnd(acceptedState);
+        stateMachine.SetAsEnd(rejectedState);
+
+        return stateMachine;
+    }
+}
+```
+
+## Views
+
+### PlantUML
+
+#### State machine diagram
+
+Use `StateMachineViewDefinition` to generate a PlantUML diagram:
+
+```csharp
+public class AbsenceStateMachinePlantUmlViewDefinition : StateMachineViewDefinition
+{
+    public const string Id = "AbsenceStateMachine";
+
+    public static StateMachineView Create(HRStateModel model)
+    {
+        var view = new StateMachineView(
+            Id,
+            model.GetStateMachine<StateMachine>());
+
+        return view;
+    }
+}
+```
+
+Output: [PlantUML diagram](AbsenceStateMachine.puml)
+
+### AsciiDoc
+
+Generate a transitions table using `StateMachineAsciiDocTableViewDefinition`.
+
+### Markdown
+
+Generate the same table in Markdown using `StateMachineMarkdownTableViewDefinition`.


### PR DESCRIPTION
## Summary
- add new documentation for State model
- link State model docs from README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451c9d3b548322a4f4650445fb9c29