### PR TITLE
Add typed attribute system to RestApiModel

### DIFF
--- a/src/Models/RestApiModel/Modeler.RestApiModel.Views.AsciiDoc/AsciiDocApiModelsViewGenerator.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel.Views.AsciiDoc/AsciiDocApiModelsViewGenerator.cs
@@ -30,7 +30,7 @@ public class AsciiDocApiModelsViewGenerator
                 foreach (var attr in model.Attributes)
                 {
                     sb.AppendLine($"|{attr.Name}");
-                    sb.AppendLine($"|{attr.Type}");
+                    sb.AppendLine($"|{attr.Type.Name}");
                     sb.AppendLine($"|{(attr.Required ? "YES" : "NO")}");
                     sb.AppendLine();
                 }

--- a/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/OpenApiViewGenerator.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/OpenApiViewGenerator.cs
@@ -89,7 +89,7 @@ public class OpenApiViewGenerator
             {
                 properties[attr.Name] = new Dictionary<string, object>
                 {
-                    ["type"] = attr.Type
+                    ["type"] = attr.Type.Name
                 };
                 if (attr.Required)
                 {

--- a/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/OpenApiYamlViewGenerator.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel.Views.OpenApi/OpenApiYamlViewGenerator.cs
@@ -158,7 +158,7 @@ public class OpenApiYamlViewGenerator
             {
                 properties[attr.Name] = new Dictionary<string, object>
                 {
-                    ["type"] = attr.Type
+                    ["type"] = attr.Type.Name
                 };
                 if (attr.Required)
                 {

--- a/src/Models/RestApiModel/Modeler.RestApiModel/ApiModel.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/ApiModel.cs
@@ -9,7 +9,7 @@ public abstract class ApiModel
         return this;
     }
 
-    public ApiModel WithAttribute(string name, string type, bool required)
+    public ApiModel WithAttribute(string name, AttributeType type, bool required)
     {
         Attributes.Add(new ApiModelAttribute(name, type, required));
         return this;

--- a/src/Models/RestApiModel/Modeler.RestApiModel/ApiModel.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/ApiModel.cs
@@ -1,3 +1,5 @@
+using Modeler.RestApiModel.Types;
+
 namespace Modeler.RestApiModel;
 
 public abstract class ApiModel

--- a/src/Models/RestApiModel/Modeler.RestApiModel/ApiModelAttribute.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/ApiModelAttribute.cs
@@ -1,3 +1,3 @@
 namespace Modeler.RestApiModel;
 
-public record ApiModelAttribute(string Name, string Type, bool Required);
+public record ApiModelAttribute(string Name, AttributeType Type, bool Required);

--- a/src/Models/RestApiModel/Modeler.RestApiModel/ApiModelAttribute.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/ApiModelAttribute.cs
@@ -1,3 +1,5 @@
+using Modeler.RestApiModel.Types;
+
 namespace Modeler.RestApiModel;
 
 public record ApiModelAttribute(string Name, AttributeType Type, bool Required);

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/ArrayType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/ArrayType.cs
@@ -1,4 +1,4 @@
-namespace Modeler.RestApiModel;
+namespace Modeler.RestApiModel.Types;
 
 public class ArrayType : AttributeType
 {

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/ArrayType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/ArrayType.cs
@@ -1,0 +1,13 @@
+namespace Modeler.RestApiModel;
+
+public class ArrayType : AttributeType
+{
+    public AttributeType ElementType { get; }
+
+    private ArrayType(AttributeType elementType) : base($"{elementType.Name}[]")
+    {
+        ElementType = elementType;
+    }
+
+    public static AttributeType Create(AttributeType elementType) => new ArrayType(elementType);
+}

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/AttributeType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/AttributeType.cs
@@ -1,0 +1,13 @@
+namespace Modeler.RestApiModel;
+
+public abstract class AttributeType
+{
+    public string Name { get; }
+
+    protected AttributeType(string name)
+    {
+        Name = name;
+    }
+
+    public override string ToString() => Name;
+}

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/AttributeType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/AttributeType.cs
@@ -1,4 +1,4 @@
-namespace Modeler.RestApiModel;
+namespace Modeler.RestApiModel.Types;
 
 public abstract class AttributeType
 {

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/BooleanType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/BooleanType.cs
@@ -1,0 +1,8 @@
+namespace Modeler.RestApiModel;
+
+public class BooleanType : AttributeType
+{
+    private BooleanType() : base("boolean") { }
+
+    public static AttributeType Create() => new BooleanType();
+}

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/BooleanType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/BooleanType.cs
@@ -1,4 +1,4 @@
-namespace Modeler.RestApiModel;
+namespace Modeler.RestApiModel.Types;
 
 public class BooleanType : AttributeType
 {

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/IntegerType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/IntegerType.cs
@@ -1,4 +1,4 @@
-namespace Modeler.RestApiModel;
+namespace Modeler.RestApiModel.Types;
 
 public class IntegerType : AttributeType
 {

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/IntegerType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/IntegerType.cs
@@ -1,0 +1,8 @@
+namespace Modeler.RestApiModel;
+
+public class IntegerType : AttributeType
+{
+    private IntegerType() : base("integer") { }
+
+    public static AttributeType Create() => new IntegerType();
+}

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/ModelType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/ModelType.cs
@@ -1,4 +1,4 @@
-namespace Modeler.RestApiModel;
+namespace Modeler.RestApiModel.Types;
 
 public class ModelType : AttributeType
 {

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/ModelType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/ModelType.cs
@@ -1,0 +1,13 @@
+namespace Modeler.RestApiModel;
+
+public class ModelType : AttributeType
+{
+    public ApiModel Model { get; }
+
+    private ModelType(ApiModel model) : base(model.Name)
+    {
+        Model = model;
+    }
+
+    public static AttributeType Create(ApiModel model) => new ModelType(model);
+}

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/NumberType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/NumberType.cs
@@ -1,4 +1,4 @@
-namespace Modeler.RestApiModel;
+namespace Modeler.RestApiModel.Types;
 
 public class NumberType : AttributeType
 {

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/NumberType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/NumberType.cs
@@ -1,0 +1,8 @@
+namespace Modeler.RestApiModel;
+
+public class NumberType : AttributeType
+{
+    private NumberType() : base("number") { }
+
+    public static AttributeType Create() => new NumberType();
+}

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/StringType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/StringType.cs
@@ -1,4 +1,4 @@
-namespace Modeler.RestApiModel;
+namespace Modeler.RestApiModel.Types;
 
 public class StringType : AttributeType
 {

--- a/src/Models/RestApiModel/Modeler.RestApiModel/Types/StringType.cs
+++ b/src/Models/RestApiModel/Modeler.RestApiModel/Types/StringType.cs
@@ -1,0 +1,8 @@
+namespace Modeler.RestApiModel;
+
+public class StringType : AttributeType
+{
+    private StringType() : base("string") { }
+
+    public static AttributeType Create() => new StringType();
+}

--- a/src/Samples/RestApi/Modeler.RestApiModel.Sample/Models/ApiModels/AddEmployeeRequest.cs
+++ b/src/Samples/RestApi/Modeler.RestApiModel.Sample/Models/ApiModels/AddEmployeeRequest.cs
@@ -1,9 +1,11 @@
+using Modeler.RestApiModel;
+
 namespace Modeler.RestApiModel.Sample.Models.ApiModels;
 
 public class AddEmployeeRequest : ApiModel
 {
     public static ApiModel Create() => new AddEmployeeRequest()
         .WithName("AddEmployeeRequest")
-        .WithAttribute("FirstName", "string", true)
-        .WithAttribute("LastName", "string", true);
+        .WithAttribute("FirstName", StringType.Create(), true)
+        .WithAttribute("LastName", StringType.Create(), true);
 }

--- a/src/Samples/RestApi/Modeler.RestApiModel.Sample/Models/ApiModels/AddEmployeeRequest.cs
+++ b/src/Samples/RestApi/Modeler.RestApiModel.Sample/Models/ApiModels/AddEmployeeRequest.cs
@@ -1,4 +1,4 @@
-using Modeler.RestApiModel;
+using Modeler.RestApiModel.Types;
 
 namespace Modeler.RestApiModel.Sample.Models.ApiModels;
 

--- a/src/Samples/RestApi/Modeler.RestApiModel.Sample/Models/ApiModels/EmployeeModel.cs
+++ b/src/Samples/RestApi/Modeler.RestApiModel.Sample/Models/ApiModels/EmployeeModel.cs
@@ -1,10 +1,12 @@
+using Modeler.RestApiModel;
+
 namespace Modeler.RestApiModel.Sample.Models.ApiModels;
 
 public class EmployeeModel : ApiModel
 {
     public static ApiModel Create() => new EmployeeModel()
         .WithName("Employee")
-        .WithAttribute("Id", "string", true)
-        .WithAttribute("FirstName", "string", true)
-        .WithAttribute("LastName", "string", true);
+        .WithAttribute("Id", StringType.Create(), true)
+        .WithAttribute("FirstName", StringType.Create(), true)
+        .WithAttribute("LastName", StringType.Create(), true);
 }

--- a/src/Samples/RestApi/Modeler.RestApiModel.Sample/Models/ApiModels/EmployeeModel.cs
+++ b/src/Samples/RestApi/Modeler.RestApiModel.Sample/Models/ApiModels/EmployeeModel.cs
@@ -1,4 +1,4 @@
-using Modeler.RestApiModel;
+using Modeler.RestApiModel.Types;
 
 namespace Modeler.RestApiModel.Sample.Models.ApiModels;
 

--- a/src/Samples/RestApi/Modeler.RestApiModel.Sample/Models/ApiModels/EmployeesResponse.cs
+++ b/src/Samples/RestApi/Modeler.RestApiModel.Sample/Models/ApiModels/EmployeesResponse.cs
@@ -1,8 +1,10 @@
+using Modeler.RestApiModel;
+
 namespace Modeler.RestApiModel.Sample.Models.ApiModels;
 
 public class EmployeesResponse : ApiModel
 {
     public static ApiModel Create() => new EmployeesResponse()
         .WithName("EmployeesResponse")
-        .WithAttribute("Employees", "Employee[]", true);
+        .WithAttribute("Employees", ArrayType.Create(ModelType.Create(EmployeeModel.Create())), true);
 }

--- a/src/Samples/RestApi/Modeler.RestApiModel.Sample/Models/ApiModels/EmployeesResponse.cs
+++ b/src/Samples/RestApi/Modeler.RestApiModel.Sample/Models/ApiModels/EmployeesResponse.cs
@@ -1,4 +1,4 @@
-using Modeler.RestApiModel;
+using Modeler.RestApiModel.Types;
 
 namespace Modeler.RestApiModel.Sample.Models.ApiModels;
 


### PR DESCRIPTION
## Summary
- implement `AttributeType` base class with primitive, model and array types
- adjust `ApiModel` and `ApiModelAttribute` to use typed attributes
- update view generators to output type names
- update sample API models to use new typed attribute types

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684520743b408322ba038064b02ff7e4