### PR TITLE
Add deployment server connections

### DIFF
--- a/src/Modeler/Models/Deployment/DeploymentServerConnection.cs
+++ b/src/Modeler/Models/Deployment/DeploymentServerConnection.cs
@@ -1,0 +1,8 @@
+namespace Modeler.Models.Deployment;
+
+public record DeploymentServerConnection(
+    DeploymentServer Source,
+    DeploymentServer Target,
+    string? Protocol,
+    int? Port
+);

--- a/src/Modeler/Models/Deployment/Model.cs
+++ b/src/Modeler/Models/Deployment/Model.cs
@@ -16,6 +16,7 @@ public abstract class Model : IModel
     private readonly List<EnvironmentServerAssignment> _environmentServers;
     private readonly List<ServerRuntimeEnvironmentAssignment> _serverRuntimeEnvironments;
     private readonly List<RuntimeComponentAssignment> _runtimeComponents;
+    private readonly List<DeploymentServerConnection> _serverConnections;
 
     protected Model(ModelElementsRegistry elementsRegistry)
     {
@@ -26,6 +27,7 @@ public abstract class Model : IModel
         _environmentServers = new List<EnvironmentServerAssignment>();
         _serverRuntimeEnvironments = new List<ServerRuntimeEnvironmentAssignment>();
         _runtimeComponents = new List<RuntimeComponentAssignment>();
+        _serverConnections = new List<DeploymentServerConnection>();
     }
 
     public DeploymentEnvironment GetEnvironment<T>() where T : DeploymentEnvironment
@@ -94,6 +96,27 @@ public abstract class Model : IModel
         _runtimeComponents.Add(new RuntimeComponentAssignment(runtimeEnvironment, component));
     }
 
+    public void ConnectServers(
+        DeploymentServer source,
+        DeploymentServer target,
+        string? protocol = null,
+        int? port = null)
+    {
+        ValidateServer(source);
+        ValidateServer(target);
+
+        if (_serverConnections.Any(connection =>
+                connection.Source == source &&
+                connection.Target == target &&
+                connection.Protocol == protocol &&
+                connection.Port == port))
+        {
+            return;
+        }
+
+        _serverConnections.Add(new DeploymentServerConnection(source, target, protocol, port));
+    }
+
     public List<DeploymentEnvironment> GetEnvironments()
     {
         return _environments.ToList();
@@ -146,6 +169,11 @@ public abstract class Model : IModel
 
         return _serverRuntimeEnvironments
             .FirstOrDefault(x => x.RuntimeEnvironment == runtimeEnvironment)?.Server;
+    }
+
+    public List<DeploymentServerConnection> GetServerConnections()
+    {
+        return _serverConnections.ToList();
     }
 
     private static TElement GetElement<TElement>(IEnumerable<TElement> elements, Type type) where TElement : class

--- a/src/Modeler/Views/Deployment/Diagram/PlantDeploymentDiagramViewGenerator.cs
+++ b/src/Modeler/Views/Deployment/Diagram/PlantDeploymentDiagramViewGenerator.cs
@@ -47,6 +47,8 @@ public class PlantDeploymentDiagramViewGenerator
                 sb.AppendLine();
             }
 
+            GenerateConnections(sb, view);
+
             sb.AppendLine("@enduml");
             sb.AppendLine();
 
@@ -146,5 +148,61 @@ public class PlantDeploymentDiagramViewGenerator
         }
 
         return new string(' ', indentLevel * _viewLayout.IndentSize);
+    }
+
+    private void GenerateConnections(StringBuilder sb, PlantUmlDeploymentDiagramView view)
+    {
+        var visibleServers = GetVisibleServers(view);
+
+        var connections = _model.GetServerConnections()
+            .Where(connection => visibleServers.Contains(connection.Source) && visibleServers.Contains(connection.Target))
+            .OrderBy(connection => connection.Source.Name)
+            .ThenBy(connection => connection.Target.Name)
+            .ThenBy(connection => connection.Protocol)
+            .ThenBy(connection => connection.Port)
+            .ToList();
+
+        foreach (var connection in connections)
+        {
+            var label = GetConnectionLabel(connection);
+            sb.AppendLine($"{connection.Source.Id} --> {connection.Target.Id}{label}");
+        }
+    }
+
+    private HashSet<DeploymentServer> GetVisibleServers(PlantUmlDeploymentDiagramView view)
+    {
+        var visibleServers = new HashSet<DeploymentServer>();
+
+        foreach (var visibleEnvironment in view.VisibleEnvironments.Where(environment => environment.NestedLevel >= 1))
+        {
+            var environmentServers = _model.GetServers(visibleEnvironment.Environment);
+
+            foreach (var server in environmentServers)
+            {
+                if (!view.HiddenServers.Contains(server))
+                {
+                    visibleServers.Add(server);
+                }
+            }
+        }
+
+        return visibleServers;
+    }
+
+    private string GetConnectionLabel(DeploymentServerConnection connection)
+    {
+        var labelParts = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(connection.Protocol))
+        {
+            labelParts.Add(connection.Protocol!);
+        }
+
+        if (connection.Port.HasValue)
+        {
+            labelParts.Add(connection.Port.Value.ToString());
+        }
+
+        return labelParts.Count > 0 ? $" : {string.Join(" ", labelParts)}" : string.Empty;
     }
 }

--- a/src/Samples/Modeler.Samples.HR/Deployment/HRDeploymentModel.cs
+++ b/src/Samples/Modeler.Samples.HR/Deployment/HRDeploymentModel.cs
@@ -27,6 +27,10 @@ public class HRDeploymentModel : Model
         AddServer(production, databaseServer);
         AddServer(production, integrationServer);
 
+        ConnectServers(frontendServer, backendServer, protocol: "HTTPS");
+        ConnectServers(backendServer, databaseServer, port: 5432);
+        ConnectServers(backendServer, integrationServer, port: 9092);
+
         var frontendRuntime = GetRuntimeEnvironment<ProductionFrontendRuntimeEnvironment>();
         var backendRuntime = GetRuntimeEnvironment<ProductionBackendRuntimeEnvironment>();
         var databaseRuntime = GetRuntimeEnvironment<ProductionDatabaseRuntimeEnvironment>();


### PR DESCRIPTION
## Summary
- add a deployment server connection model with optional protocol and port metadata
- render directed server connections on PlantUML deployment diagrams when both servers are visible
- wire up sample HR deployment servers with HTTPS, PostgreSQL, and Kafka connections

## Testing
- dotnet build Modeler.sln *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d82cedcbd483228e5cb1cfec172b16